### PR TITLE
[HackWeek] Support computation of embeddings in Apache Iceberg tables. v1.7.x

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -77,6 +77,12 @@ public interface ActionsProvider {
         this.getClass().getName() + " does not implement computeTableStats");
   }
 
+  /** Instantiates an action to compute table embeddings. * */
+  default ComputeTableEmbeddings computeTableEmbeddings(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement computeTableEmbeddings");
+  }
+
   /** Instantiates an action to rewrite all absolute paths in table metadata. */
   default RewriteTablePath rewriteTablePath(Table table) {
     throw new UnsupportedOperationException(

--- a/api/src/main/java/org/apache/iceberg/actions/ComputeTableEmbeddings.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ComputeTableEmbeddings.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.util.Map;
+import org.apache.iceberg.StatisticsFile;
+
+public interface ComputeTableEmbeddings
+    extends Action<ComputeTableEmbeddings, ComputeTableEmbeddings.Result> {
+
+  /**
+   * Choose the set of columns to compute embeddings, by default all columns are chosen. Embeddings
+   * are computed only of columns of type string.
+   *
+   * @param columns a set of column names to be compute embeddings
+   * @return this for method chaining
+   */
+  ComputeTableEmbeddings columns(String... columns);
+
+  /**
+   * Choose the table snapshot to compute embeddings, by default the current snapshot is used.
+   *
+   * @param snapshotId long ID of the snapshot for which embeddings need to be computed
+   * @return this for method chaining
+   */
+  ComputeTableEmbeddings snapshot(long snapshotId);
+
+  /**
+   * Choose the model to use for computing embeddings, by default the in-process minilm model is
+   * used.
+   *
+   * @param modelName model name used for computing embeddings.
+   * @return this for method chaining
+   */
+  ComputeTableEmbeddings modelName(String modelName);
+
+  /**
+   * Choose the model inputs maps to use for model initialization, by default the empty map is used.
+   *
+   * @param modelInputs model inputs used for model initialization.
+   * @return this for method chaining
+   */
+  ComputeTableEmbeddings modelInputs(Map<String, String> modelInputs);
+
+  /** The result of table statistics collection. */
+  interface Result {
+    /** Returns statistics file or none if no statistics were collected. */
+    StatisticsFile statisticsFile();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseComputeTableEmbeddings.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseComputeTableEmbeddings.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.StatisticsFile;
+import org.immutables.value.Value;
+
+@Value.Enclosing
+@SuppressWarnings("ImmutablesStyle")
+@Value.Style(
+    typeImmutableEnclosing = "ImmutableComputeTableEmbeddings",
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
+interface BaseComputeTableEmbeddings extends ComputeTableEmbeddings {
+
+  @Value.Immutable
+  interface Result extends ComputeTableEmbeddings.Result {
+    @Override
+    @Nullable
+    StatisticsFile statisticsFile();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -29,4 +29,7 @@ public final class StandardBlobTypes {
 
   /** A serialized deletion vector according to the Iceberg spec */
   public static final String DV_V1 = "deletion-vector-v1";
+
+  /** A serialized embedding representation using a chosen model */
+  public static final String EMBEDDINGS_V1 = "embedding-v1";
 }

--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -181,6 +181,28 @@ for Puffin v1.
 [roaring-bitmap-portable-serialization]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#extension-for-64-bit-implementations
 [roaring-bitmap-general-layout]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#general-layout
 
+
+#### `embedding` blob type
+
+A serialized form of an embedding for select string-type columns using chosen model.
+Embedding is process of converting complex data (e.g., text, images, audio) into a
+dense vector representation that can be used for tasks like similarity search,
+clustering, and classification. To compute embeddings we leverage [langchain4j](https://docs.langchain4j.dev/)
+which comes with builtin [embedding models](https://docs.langchain4j.dev/category/embedding-models).
+
+The serialized blob is a JSON representation list of [input text, metadata][text-segment]
+and its [embedding][embedding]. Metadata includes following properties:
+
+- `column_name`: Name of the column for which embedding is being computed.
+- `model_name`: Name of the model used to compute the embedding.
+
+[text-segment]: https://github.com/langchain4j/langchain4j/blob/main/langchain4j-core/src/main/java/dev/langchain4j/data/segment/TextSegment.java
+[embedding]: https://github.com/langchain4j/langchain4j/blob/main/langchain4j-core/src/main/java/dev/langchain4j/data/embedding/Embedding.java
+
+The blob metadata for this blob may include following properties:
+
+- `embeddings`: Number of embeddings computed for the given column.
+
 ### Compression codecs
 
 The data can also be uncompressed. If it is compressed the codec should be one of

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ calcite = "1.10.0"
 datasketches = "6.1.1"
 delta-standalone = "3.3.0"
 delta-spark = "3.2.1"
+djl = "0.20.0"
 langchain4j = "1.0.0-alpha1"
 esotericsoftware-kryo = "4.0.3"
 errorprone-annotations = "2.36.0"
@@ -107,7 +108,11 @@ calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "ca
 datasketches = { module = "org.apache.datasketches:datasketches-java", version.ref = "datasketches" }
 delta-standalone = { module = "io.delta:delta-standalone_2.12", version.ref = "delta-standalone" }
 dev-langchain4j = { module = "dev.langchain4j:langchain4j", version.ref = "langchain4j" }
-dev-langchain4j-minilm = { module = "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2-q", version.ref = "langchain4j" }
+ai-djl-api = { module = "ai.djl:api", version.ref = "djl" }
+ai-djl-huggingface-tokenizers = { module = "ai.djl.huggingface:tokenizers", version.ref = "djl" }
+dev-langchain4j-embeddings = { module = "dev.langchain4j:langchain4j-embeddings", version.ref = "langchain4j" }
+dev-langchain4j-embeddings-minilm = { module = "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2", version.ref = "langchain4j" }
+dev-langchain4j-ollama = { module = "dev.langchain4j:langchain4j-ollama", version.ref = "langchain4j" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
 failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe"}
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ calcite = "1.10.0"
 datasketches = "6.1.1"
 delta-standalone = "3.3.0"
 delta-spark = "3.2.1"
+langchain4j = "1.0.0-alpha1"
 esotericsoftware-kryo = "4.0.3"
 errorprone-annotations = "2.36.0"
 failsafe = "3.3.2"
@@ -105,6 +106,8 @@ calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calc
 calcite-druid = { module = "org.apache.calcite:calcite-druid", version.ref = "calcite" }
 datasketches = { module = "org.apache.datasketches:datasketches-java", version.ref = "datasketches" }
 delta-standalone = { module = "io.delta:delta-standalone_2.12", version.ref = "delta-standalone" }
+dev-langchain4j = { module = "dev.langchain4j:langchain4j", version.ref = "langchain4j" }
+dev-langchain4j-minilm = { module = "dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2-q", version.ref = "langchain4j" }
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref = "errorprone-annotations" }
 failsafe = { module = "dev.failsafe:failsafe", version.ref = "failsafe"}
 findbugs-jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr305" }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -65,6 +65,9 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
       implementation 'org.scala-lang:scala-library:2.12.18'
     }
 
+    implementation libs.dev.langchain4j
+    implementation libs.dev.langchain4j.minilm
+
     compileOnly libs.errorprone.annotations
     compileOnly libs.avro.avro
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -60,13 +60,16 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation project(':iceberg-arrow')
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
     implementation("org.apache.datasketches:datasketches-java:${libs.versions.datasketches.get()}")
+    implementation(libs.dev.langchain4j)
+    implementation(libs.dev.langchain4j.embeddings)
+    implementation(libs.dev.langchain4j.ollama)
+    implementation(libs.dev.langchain4j.embeddings.minilm)
+    implementation libs.ai.djl.huggingface.tokenizers
+
     if (scalaVersion == '2.12') {
       // scala-collection-compat_2.12 pulls scala 2.12.17 and we need 2.12.18 for JDK 21 support
       implementation 'org.scala-lang:scala-library:2.12.18'
     }
-
-    implementation libs.dev.langchain4j
-    implementation libs.dev.langchain4j.minilm
 
     compileOnly libs.errorprone.annotations
     compileOnly libs.avro.avro
@@ -319,6 +322,9 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
     relocate 'org.apache.datasketches', 'org.apache.iceberg.shaded.org.apache.datasketches'
+    relocate 'dev.langchain4j', 'org.apache.iceberg.shaded.dev.langchain4j'
+    relocate 'ai.djl', 'org.apache.iceberg.shaded.ai.djl'
+    relocate 'org.apache.httpcomponents', 'org.apache.iceberg.org.apache.httpcomponents'
 
     archiveClassifier.set(null)
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
@@ -90,13 +90,15 @@ public class ComputeTableEmbeddingsSparkAction
 
   @Override
   public ComputeTableEmbeddings modelName(String newModelName) {
-    Preconditions.checkArgument(newModelName != null && !newModelName.isEmpty(), "Model name cannot be null or empty");
+    Preconditions.checkArgument(
+        newModelName != null && !newModelName.isEmpty(), "Model name cannot be null or empty");
     this.modelName = newModelName;
     return this;
   }
 
   @Override
   public ComputeTableEmbeddings modelInputs(Map<String, String> newModelInputs) {
+    Preconditions.checkArgument(newModelInputs != null, "Model inputs cannot be null");
     this.modelInputs = newModelInputs;
     return this;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.iceberg.GenericBlobMetadata;
+import org.apache.iceberg.GenericStatisticsFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.actions.ComputeTableEmbeddings;
+import org.apache.iceberg.actions.ImmutableComputeTableEmbeddings;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.puffin.Blob;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ComputeTableEmbeddingsSparkAction
+    extends BaseSparkAction<ComputeTableEmbeddingsSparkAction> implements ComputeTableEmbeddings {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ComputeTableEmbeddingsSparkAction.class);
+  private static final ComputeTableEmbeddings.Result EMPTY_RESULT =
+      ImmutableComputeTableEmbeddings.Result.builder().build();
+
+  private final Table table;
+  private List<String> columns;
+  private Snapshot snapshot;
+  private String modelName;
+  private Map<String, String> modelInputs;
+
+  ComputeTableEmbeddingsSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    this.snapshot = table.currentSnapshot();
+  }
+
+  @Override
+  protected ComputeTableEmbeddingsSparkAction self() {
+    return this;
+  }
+
+  @Override
+  public ComputeTableEmbeddings columns(String... newColumns) {
+    Preconditions.checkArgument(
+        newColumns != null && newColumns.length > 0, "Columns cannot be null/empty");
+    this.columns = ImmutableList.copyOf(ImmutableSet.copyOf(newColumns));
+    return this;
+  }
+
+  @Override
+  public ComputeTableEmbeddings snapshot(long newSnapshotId) {
+    Snapshot newSnapshot = table.snapshot(newSnapshotId);
+    Preconditions.checkArgument(newSnapshot != null, "Snapshot not found: %s", newSnapshotId);
+    this.snapshot = newSnapshot;
+    return this;
+  }
+
+  @Override
+  public ComputeTableEmbeddings modelName(String newModelName) {
+    Preconditions.checkArgument(newModelName != null && !newModelName.isEmpty(), "Model name cannot be null or empty");
+    this.modelName = newModelName;
+    return this;
+  }
+
+  @Override
+  public ComputeTableEmbeddings modelInputs(Map<String, String> newModelInputs) {
+    this.modelInputs = newModelInputs;
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    if (snapshot == null) {
+      LOG.info("No snapshot to compute embeddings for table {}", table.name());
+      return EMPTY_RESULT;
+    }
+    validateColumns();
+    JobGroupInfo info = newJobGroupInfo("COMPUTE-TABLE-EMBEDDINGS", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private ComputeTableEmbeddings.Result doExecute() {
+    LOG.info(
+        "Computing embedding for columns {} in {} (snapshot {})",
+        columns(),
+        table.name(),
+        snapshotId());
+    List<Blob> blobs = generateEmbeddings();
+    StatisticsFile statisticsFile = writeStatsFile(blobs);
+    table.updateStatistics().setStatistics(snapshotId(), statisticsFile).commit();
+    return ImmutableComputeTableEmbeddings.Result.builder().statisticsFile(statisticsFile).build();
+  }
+
+  private StatisticsFile writeStatsFile(List<Blob> blobs) {
+    LOG.info("Writing embeddings for table {} for snapshot {}", table.name(), snapshotId());
+    OutputFile outputFile = table.io().newOutputFile(outputPath());
+    try (PuffinWriter writer = Puffin.write(outputFile).createdBy(appIdentifier()).build()) {
+      blobs.forEach(writer::add);
+      writer.finish();
+      return new GenericStatisticsFile(
+          snapshotId(),
+          outputFile.location(),
+          writer.fileSize(),
+          writer.footerSize(),
+          GenericBlobMetadata.from(writer.writtenBlobsMetadata()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<Blob> generateEmbeddings() {
+    return TextEmbeddingUtil.generateBlobs(
+        spark(), table, snapshot, columns, modelName, modelInputs);
+  }
+
+  private void validateColumns() {
+    Schema schema = table.schemas().get(snapshot.schemaId());
+    Preconditions.checkArgument(!columns().isEmpty(), "No columns found to compute embeddings");
+    for (String columnName : columns()) {
+      Types.NestedField field = schema.findField(columnName);
+      Preconditions.checkArgument(field != null, "Can't find column %s in %s", columnName, schema);
+      Preconditions.checkArgument(
+          field.type().isPrimitiveType(),
+          "Can't compute embeddings on non-primitive type column: %s (%s)",
+          columnName,
+          field.type());
+      Preconditions.checkArgument(
+          field.type().typeId() == Types.StringType.get().typeId(),
+          "Can't compute embeddings on non-string type columns: %s (%s)",
+          columnName,
+          field.type());
+    }
+  }
+
+  private List<String> columns() {
+    if (columns == null) {
+      Schema schema = table.schemas().get(snapshot.schemaId());
+      this.columns =
+          schema.columns().stream()
+              .filter(nestedField -> nestedField.type().isPrimitiveType())
+              .map(Types.NestedField::name)
+              .collect(Collectors.toList());
+    }
+    return columns;
+  }
+
+  private String appIdentifier() {
+    String icebergVersion = IcebergBuild.fullVersion();
+    String sparkVersion = spark().version();
+    return String.format("Iceberg %s Spark %s", icebergVersion, sparkVersion);
+  }
+
+  private long snapshotId() {
+    return snapshot.snapshotId();
+  }
+
+  private String jobDesc() {
+    return String.format(
+        "Computing table embedding for %s (snapshot_id=%s, columns=%s)",
+        table.name(), snapshotId(), columns());
+  }
+
+  private String outputPath() {
+    TableOperations operations = ((HasTableOperations) table).operations();
+    String fileName = String.format("%s-%s.embedding", snapshotId(), UUID.randomUUID());
+    return operations.metadataFileLocation(fileName);
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/ComputeTableEmbeddingsSparkAction.java
@@ -150,7 +150,8 @@ public class ComputeTableEmbeddingsSparkAction
 
   private void validateColumns() {
     Schema schema = table.schemas().get(snapshot.schemaId());
-    Preconditions.checkArgument(!columns().isEmpty(), "No columns found to compute embeddings");
+    Preconditions.checkArgument(
+        !columns.isEmpty() && !columns().isEmpty(), "No columns found to compute embeddings");
     for (String columnName : columns()) {
       Types.NestedField field = schema.findField(columnName);
       Preconditions.checkArgument(field != null, "Can't find column %s in %s", columnName, schema);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
@@ -51,17 +51,19 @@ public class EmbeddingModelBuilder {
   private String modelName;
   private Map<String, String> modelInputs;
 
+  private EmbeddingModelBuilder() {}
+
   public static EmbeddingModelBuilder builder() {
     return new EmbeddingModelBuilder();
   }
 
-  public EmbeddingModelBuilder modelName(String modelName) {
-    this.modelName = modelName;
+  public EmbeddingModelBuilder modelName(String name) {
+    this.modelName = name;
     return this;
   }
 
-  public EmbeddingModelBuilder modelInputs(Map<String, String> modelInputs) {
-    this.modelInputs = modelInputs;
+  public EmbeddingModelBuilder modelInputs(Map<String, String> inputs) {
+    this.modelInputs = inputs;
     return this;
   }
 
@@ -70,7 +72,7 @@ public class EmbeddingModelBuilder {
       case ALL_MINI_LM_L6V2:
         return buildAllMiniLmL6V2EmbeddingModel();
       case OLLAMA_LLAMA_31:
-        return buildOllamaEmbeddingModel(modelName, modelInputs);
+        return buildOllamaEmbeddingModel();
       default:
         throw new UnsupportedOperationException("Model is not supported");
     }
@@ -82,8 +84,7 @@ public class EmbeddingModelBuilder {
     return new AllMiniLmL6V2EmbeddingModel();
   }
 
-  private OllamaEmbeddingModel buildOllamaEmbeddingModel(
-      String modelName, Map<String, String> modelInputs) {
+  private OllamaEmbeddingModel buildOllamaEmbeddingModel() {
     String baseUrl = modelInputs.getOrDefault(OLLAMA_BASE_URL, OLLAMA_DEFAULT_BASE_URL);
     String ollamaModelName = modelName.split("/")[1];
     Duration duration =

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.actions;
 
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -31,79 +28,92 @@ import java.util.stream.Collectors;
 
 public class EmbeddingModelBuilder {
 
-    // Models that run in the JVM.
-    public static final String ALL_MINI_LM_L6V2 = "allminilml6v2";
+  // Models that run in the JVM.
+  public static final String ALL_MINI_LM_L6V2 = "allminilml6v2";
 
-    // Models that have dependencies to remote services.
-    public static final String OLLAMA_LLAMA_31 = "ollama/llama3.1";
+  // Models that have dependencies to remote services.
+  public static final String OLLAMA_LLAMA_31 = "ollama/llama3.1";
 
-    // Model Defaults
-    // Ollama model input keys
-    public static final String OLLAMA_BASE_URL = "baseUrl";
-    public static final String OLLAMA_TIMEOUT_SECS = "timeoutSecs";
-    public static final String OLLAMA_LOG_REQUEST = "logRequest";
-    public static final String OLLAMA_LOG_RESPONSE = "logResponse";
-    private static final String OLLAMA_MAX_RETRIES = "maxRetries";
-    // Ollama model input default values
-    private static final String OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/";
-    private static final String OLLAMA_DEFAULT_TIMEOUT_SECS = "10";
-    private static final String OLLAMA_DEFAULT_MAX_RETRIES = "3";
-    private static final String OLLAMA_DEFAULT_LOG_REQUEST = "false";
-    private static final String OLLAMA_DEFAULT_LOG_RESPONSE = "false";
+  // Model Defaults
+  // Ollama model input keys
+  public static final String OLLAMA_BASE_URL = "baseUrl";
+  public static final String OLLAMA_TIMEOUT_SECS = "timeoutSecs";
+  public static final String OLLAMA_LOG_REQUEST = "logRequest";
+  public static final String OLLAMA_LOG_RESPONSE = "logResponse";
+  private static final String OLLAMA_MAX_RETRIES = "maxRetries";
+  // Ollama model input default values
+  private static final String OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/";
+  private static final String OLLAMA_DEFAULT_TIMEOUT_SECS = "10";
+  private static final String OLLAMA_DEFAULT_MAX_RETRIES = "3";
+  private static final String OLLAMA_DEFAULT_LOG_REQUEST = "false";
+  private static final String OLLAMA_DEFAULT_LOG_RESPONSE = "false";
 
-    private String modelName;
-    private Map<String, String> modelInputs;
+  private String modelName;
+  private Map<String, String> modelInputs;
 
-    public static EmbeddingModelBuilder builder() {
-        return new EmbeddingModelBuilder();
+  public static EmbeddingModelBuilder builder() {
+    return new EmbeddingModelBuilder();
+  }
+
+  public EmbeddingModelBuilder modelName(String modelName) {
+    this.modelName = modelName;
+    return this;
+  }
+
+  public EmbeddingModelBuilder modelInputs(Map<String, String> modelInputs) {
+    this.modelInputs = modelInputs;
+    return this;
+  }
+
+  public EmbeddingModel build() {
+    switch (this.modelName) {
+      case ALL_MINI_LM_L6V2:
+        return buildAllMiniLmL6V2EmbeddingModel();
+      case OLLAMA_LLAMA_31:
+        return buildOllamaEmbeddingModel(modelName, modelInputs);
+      default:
+        throw new UnsupportedOperationException("Model is not supported");
     }
+  }
 
-    public EmbeddingModelBuilder modelName(String modelName) {
-        this.modelName = modelName;
-        return this;
-    }
+  private AllMiniLmL6V2EmbeddingModel buildAllMiniLmL6V2EmbeddingModel() {
+    System.setProperty("ai.djl.offline", "true");
+    System.setProperty("DJL_OFFLINE", "true");
+    return new AllMiniLmL6V2EmbeddingModel();
+  }
 
-    public EmbeddingModelBuilder modelInputs(Map<String, String> modelInputs) {
-        this.modelInputs = modelInputs;
-        return this;
-    }
-
-    public EmbeddingModel build() {
-        switch (this.modelName) {
-            case ALL_MINI_LM_L6V2:
-                return buildAllMiniLmL6V2EmbeddingModel();
-            case OLLAMA_LLAMA_31:
-                return buildOllamaEmbeddingModel(modelName, modelInputs);
-            default:
-                throw new UnsupportedOperationException("Model is not supported");
-        }
-    }
-
-    private AllMiniLmL6V2EmbeddingModel buildAllMiniLmL6V2EmbeddingModel() {
-        System.setProperty("ai.djl.offline", "true");
-        System.setProperty("DJL_OFFLINE", "true");
-        return new AllMiniLmL6V2EmbeddingModel();
-    }
-
-    private OllamaEmbeddingModel buildOllamaEmbeddingModel(String modelName, Map<String, String> modelInputs) {
-        String baseUrl = modelInputs.getOrDefault(OLLAMA_BASE_URL,
-                OLLAMA_DEFAULT_BASE_URL);
-        String ollamaModelName = modelName.split("/")[1];
-        Duration duration = Duration.ofSeconds(Long.parseLong(modelInputs.getOrDefault(OLLAMA_TIMEOUT_SECS, OLLAMA_DEFAULT_TIMEOUT_SECS)));
-        int maxRetries = Integer.parseInt(modelInputs.getOrDefault(OLLAMA_MAX_RETRIES, OLLAMA_DEFAULT_MAX_RETRIES));
-        boolean logRequest = Boolean.parseBoolean(modelInputs.getOrDefault(OLLAMA_LOG_REQUEST, OLLAMA_DEFAULT_LOG_REQUEST));
-        boolean logResponse = Boolean.parseBoolean(modelInputs.getOrDefault(OLLAMA_LOG_RESPONSE, OLLAMA_DEFAULT_LOG_RESPONSE));
-        Set<String> skippedKeys = Set.of(OLLAMA_BASE_URL, OLLAMA_TIMEOUT_SECS, OLLAMA_MAX_RETRIES, OLLAMA_LOG_REQUEST, OLLAMA_LOG_RESPONSE);
-        return new OllamaEmbeddingModel(
-                baseUrl,
-                ollamaModelName,
-                duration,
-                maxRetries,
-                logRequest,
-                logResponse,
-                modelInputs.entrySet().stream()
-                        .filter(entry -> !skippedKeys.contains(entry.getKey()))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
+  private OllamaEmbeddingModel buildOllamaEmbeddingModel(
+      String modelName, Map<String, String> modelInputs) {
+    String baseUrl = modelInputs.getOrDefault(OLLAMA_BASE_URL, OLLAMA_DEFAULT_BASE_URL);
+    String ollamaModelName = modelName.split("/")[1];
+    Duration duration =
+        Duration.ofSeconds(
+            Long.parseLong(
+                modelInputs.getOrDefault(OLLAMA_TIMEOUT_SECS, OLLAMA_DEFAULT_TIMEOUT_SECS)));
+    int maxRetries =
+        Integer.parseInt(modelInputs.getOrDefault(OLLAMA_MAX_RETRIES, OLLAMA_DEFAULT_MAX_RETRIES));
+    boolean logRequest =
+        Boolean.parseBoolean(
+            modelInputs.getOrDefault(OLLAMA_LOG_REQUEST, OLLAMA_DEFAULT_LOG_REQUEST));
+    boolean logResponse =
+        Boolean.parseBoolean(
+            modelInputs.getOrDefault(OLLAMA_LOG_RESPONSE, OLLAMA_DEFAULT_LOG_RESPONSE));
+    Set<String> skippedKeys =
+        Set.of(
+            OLLAMA_BASE_URL,
+            OLLAMA_TIMEOUT_SECS,
+            OLLAMA_MAX_RETRIES,
+            OLLAMA_LOG_REQUEST,
+            OLLAMA_LOG_RESPONSE);
+    return new OllamaEmbeddingModel(
+        baseUrl,
+        ollamaModelName,
+        duration,
+        maxRetries,
+        logRequest,
+        logResponse,
+        modelInputs.entrySet().stream()
+            .filter(entry -> !skippedKeys.contains(entry.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/EmbeddingModelBuilder.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class EmbeddingModelBuilder {
+
+    // Models that run in the JVM.
+    public static final String ALL_MINI_LM_L6V2 = "allminilml6v2";
+
+    // Models that have dependencies to remote services.
+    public static final String OLLAMA_LLAMA_31 = "ollama/llama3.1";
+
+    // Model Defaults
+    // Ollama model input keys
+    public static final String OLLAMA_BASE_URL = "baseUrl";
+    public static final String OLLAMA_TIMEOUT_SECS = "timeoutSecs";
+    public static final String OLLAMA_LOG_REQUEST = "logRequest";
+    public static final String OLLAMA_LOG_RESPONSE = "logResponse";
+    private static final String OLLAMA_MAX_RETRIES = "maxRetries";
+    // Ollama model input default values
+    private static final String OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434/";
+    private static final String OLLAMA_DEFAULT_TIMEOUT_SECS = "10";
+    private static final String OLLAMA_DEFAULT_MAX_RETRIES = "3";
+    private static final String OLLAMA_DEFAULT_LOG_REQUEST = "false";
+    private static final String OLLAMA_DEFAULT_LOG_RESPONSE = "false";
+
+    private String modelName;
+    private Map<String, String> modelInputs;
+
+    public static EmbeddingModelBuilder builder() {
+        return new EmbeddingModelBuilder();
+    }
+
+    public EmbeddingModelBuilder modelName(String modelName) {
+        this.modelName = modelName;
+        return this;
+    }
+
+    public EmbeddingModelBuilder modelInputs(Map<String, String> modelInputs) {
+        this.modelInputs = modelInputs;
+        return this;
+    }
+
+    public EmbeddingModel build() {
+        switch (this.modelName) {
+            case ALL_MINI_LM_L6V2:
+                return buildAllMiniLmL6V2EmbeddingModel();
+            case OLLAMA_LLAMA_31:
+                return buildOllamaEmbeddingModel(modelName, modelInputs);
+            default:
+                throw new UnsupportedOperationException("Model is not supported");
+        }
+    }
+
+    private AllMiniLmL6V2EmbeddingModel buildAllMiniLmL6V2EmbeddingModel() {
+        System.setProperty("ai.djl.offline", "true");
+        System.setProperty("DJL_OFFLINE", "true");
+        return new AllMiniLmL6V2EmbeddingModel();
+    }
+
+    private OllamaEmbeddingModel buildOllamaEmbeddingModel(String modelName, Map<String, String> modelInputs) {
+        String baseUrl = modelInputs.getOrDefault(OLLAMA_BASE_URL,
+                OLLAMA_DEFAULT_BASE_URL);
+        String ollamaModelName = modelName.split("/")[1];
+        Duration duration = Duration.ofSeconds(Long.parseLong(modelInputs.getOrDefault(OLLAMA_TIMEOUT_SECS, OLLAMA_DEFAULT_TIMEOUT_SECS)));
+        int maxRetries = Integer.parseInt(modelInputs.getOrDefault(OLLAMA_MAX_RETRIES, OLLAMA_DEFAULT_MAX_RETRIES));
+        boolean logRequest = Boolean.parseBoolean(modelInputs.getOrDefault(OLLAMA_LOG_REQUEST, OLLAMA_DEFAULT_LOG_REQUEST));
+        boolean logResponse = Boolean.parseBoolean(modelInputs.getOrDefault(OLLAMA_LOG_RESPONSE, OLLAMA_DEFAULT_LOG_RESPONSE));
+        Set<String> skippedKeys = Set.of(OLLAMA_BASE_URL, OLLAMA_TIMEOUT_SECS, OLLAMA_MAX_RETRIES, OLLAMA_LOG_REQUEST, OLLAMA_LOG_RESPONSE);
+        return new OllamaEmbeddingModel(
+                baseUrl,
+                ollamaModelName,
+                duration,
+                maxRetries,
+                logRequest,
+                logResponse,
+                modelInputs.entrySet().stream()
+                        .filter(entry -> !skippedKeys.contains(entry.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.ComputeTableEmbeddings;
 import org.apache.iceberg.actions.ComputeTableStats;
 import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
 import org.apache.iceberg.spark.Spark3Util;
@@ -102,6 +103,11 @@ public class SparkActions implements ActionsProvider {
   @Override
   public ComputeTableStats computeTableStats(Table table) {
     return new ComputeTableStatsSparkAction(spark, table);
+  }
+
+  @Override
+  public ComputeTableEmbeddings computeTableEmbeddings(Table table) {
+    return new ComputeTableEmbeddingsSparkAction(spark, table);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbedding.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbedding.java
@@ -1,43 +1,40 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.actions;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 
 public class TextEmbedding {
-    private final TextSegment textSegment;
-    private final Embedding embedding;
+  private final TextSegment textSegment;
+  private final Embedding embedding;
 
-    public TextEmbedding(TextSegment textSegment, Embedding embedding) {
-        this.textSegment = textSegment;
-        this.embedding = embedding;
-    }
+  public TextEmbedding(TextSegment textSegment, Embedding embedding) {
+    this.textSegment = textSegment;
+    this.embedding = embedding;
+  }
 
-    public TextSegment getTextSegment() {
-        return this.textSegment;
-    }
+  public TextSegment getTextSegment() {
+    return this.textSegment;
+  }
 
-    public Embedding getEmbedding() {
-        return this.embedding;
-    }
+  public Embedding getEmbedding() {
+    return this.embedding;
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbedding.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbedding.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+
+public class TextEmbedding {
+    private final TextSegment textSegment;
+    private final Embedding embedding;
+
+    public TextEmbedding(TextSegment textSegment, Embedding embedding) {
+        this.textSegment = textSegment;
+        this.embedding = embedding;
+    }
+
+    public TextSegment getTextSegment() {
+        return this.textSegment;
+    }
+
+    public Embedding getEmbedding() {
+        return this.embedding;
+    }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBuffer.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBuffer.java
@@ -1,28 +1,24 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.actions;
 
 import com.google.gson.GsonBuilder;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,41 +26,42 @@ import java.util.stream.Stream;
 
 public class TextEmbeddingBuffer {
 
-    private final List<TextEmbedding> textEmbeddings;
+  private final List<TextEmbedding> textEmbeddings;
 
-    public TextEmbeddingBuffer(List<TextEmbedding> textEmbeddings) {
-        this.textEmbeddings = textEmbeddings;
-    }
+  public TextEmbeddingBuffer(List<TextEmbedding> textEmbeddings) {
+    this.textEmbeddings = textEmbeddings;
+  }
 
-    public static TextEmbeddingBuffer deserialize(byte[] bytes) {
-        String jsonString = new String(bytes, StandardCharsets.UTF_8);
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
-                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
-        return gsonBuilder.create().fromJson(jsonString, TextEmbeddingBuffer.class);
-    }
+  public static TextEmbeddingBuffer deserialize(byte[] bytes) {
+    String jsonString = new String(bytes, StandardCharsets.UTF_8);
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(
+        TextEmbeddingBuffer.class, new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+    return gsonBuilder.create().fromJson(jsonString, TextEmbeddingBuffer.class);
+  }
 
-    public List<TextEmbedding> getTextEmbeddings() {
-        return this.textEmbeddings;
-    }
+  public List<TextEmbedding> getTextEmbeddings() {
+    return this.textEmbeddings;
+  }
 
-    public TextEmbeddingBuffer merge(TextEmbeddingBuffer other) {
-        return new TextEmbeddingBuffer(Stream.concat(this.getTextEmbeddings().stream(),
-                other.getTextEmbeddings().stream()).collect(Collectors.toList()));
-    }
+  public TextEmbeddingBuffer merge(TextEmbeddingBuffer other) {
+    return new TextEmbeddingBuffer(
+        Stream.concat(this.getTextEmbeddings().stream(), other.getTextEmbeddings().stream())
+            .collect(Collectors.toList()));
+  }
 
-    public byte[] serialize() {
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
-                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
-        return gsonBuilder.create().toJson(this).getBytes(StandardCharsets.UTF_8);
-    }
+  public byte[] serialize() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(
+        TextEmbeddingBuffer.class, new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+    return gsonBuilder.create().toJson(this).getBytes(StandardCharsets.UTF_8);
+  }
 
-    @Override
-    public String toString() {
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
-                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
-        return gsonBuilder.create().toJson(this);
-    }
+  @Override
+  public String toString() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    gsonBuilder.registerTypeAdapter(
+        TextEmbeddingBuffer.class, new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+    return gsonBuilder.create().toJson(this);
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBuffer.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBuffer.java
@@ -1,0 +1,70 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import com.google.gson.GsonBuilder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TextEmbeddingBuffer {
+
+    private final List<TextEmbedding> textEmbeddings;
+
+    public TextEmbeddingBuffer(List<TextEmbedding> textEmbeddings) {
+        this.textEmbeddings = textEmbeddings;
+    }
+
+    public static TextEmbeddingBuffer deserialize(byte[] bytes) {
+        String jsonString = new String(bytes, StandardCharsets.UTF_8);
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
+                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+        return gsonBuilder.create().fromJson(jsonString, TextEmbeddingBuffer.class);
+    }
+
+    public List<TextEmbedding> getTextEmbeddings() {
+        return this.textEmbeddings;
+    }
+
+    public TextEmbeddingBuffer merge(TextEmbeddingBuffer other) {
+        return new TextEmbeddingBuffer(Stream.concat(this.getTextEmbeddings().stream(),
+                other.getTextEmbeddings().stream()).collect(Collectors.toList()));
+    }
+
+    public byte[] serialize() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
+                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+        return gsonBuilder.create().toJson(this).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String toString() {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(TextEmbeddingBuffer.class,
+                new TextEmbeddingBufferTypeAdapter<TextEmbeddingBuffer>());
+        return gsonBuilder.create().toJson(this);
+    }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBufferTypeAdapter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBufferTypeAdapter.java
@@ -1,24 +1,21 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.actions;
 
 import com.google.gson.Gson;
@@ -29,15 +26,15 @@ import java.io.IOException;
 
 public class TextEmbeddingBufferTypeAdapter<T> extends TypeAdapter<TextEmbeddingBuffer> {
 
-    @Override
-    public void write(JsonWriter out, TextEmbeddingBuffer value) throws IOException {
-        Gson gson = new Gson();
-        out.jsonValue(gson.toJson(value));
-    }
+  @Override
+  public void write(JsonWriter out, TextEmbeddingBuffer value) throws IOException {
+    Gson gson = new Gson();
+    out.jsonValue(gson.toJson(value));
+  }
 
-    @Override
-    public TextEmbeddingBuffer read(JsonReader in) throws IOException {
-        Gson gson = new Gson();
-        return gson.fromJson(in, TextEmbeddingBuffer.class);
-    }
+  @Override
+  public TextEmbeddingBuffer read(JsonReader in) throws IOException {
+    Gson gson = new Gson();
+    return gson.fromJson(in, TextEmbeddingBuffer.class);
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBufferTypeAdapter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingBufferTypeAdapter.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+public class TextEmbeddingBufferTypeAdapter<T> extends TypeAdapter<TextEmbeddingBuffer> {
+
+    @Override
+    public void write(JsonWriter out, TextEmbeddingBuffer value) throws IOException {
+        Gson gson = new Gson();
+        out.jsonValue(gson.toJson(value));
+    }
+
+    @Override
+    public TextEmbeddingBuffer read(JsonReader in) throws IOException {
+        Gson gson = new Gson();
+        return gson.fromJson(in, TextEmbeddingBuffer.class);
+    }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingPuffinWriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingPuffinWriter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.puffin.Blob;
+import org.apache.iceberg.puffin.PuffinCompressionCodec;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.index.EmbeddingAgg;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+
+public class TextEmbeddingPuffinWriter {
+
+  private static final String NUM_EMBEDDINGS = "num_embeddings";
+
+  private TextEmbeddingPuffinWriter() {}
+
+  static List<Blob> generateBlobs(
+      SparkSession spark,
+      Table table,
+      Snapshot snapshot,
+      List<String> columns,
+      String modelName,
+      Map<String, String> modelInputs) {
+    Row embeddings = computeEmbeddings(spark, table, snapshot, columns, modelName, modelInputs);
+    Schema schema = table.schemas().get(snapshot.schemaId());
+    List<Blob> blobs = Lists.newArrayList();
+    for (int i = 0; i < columns.size(); i++) {
+      Types.NestedField field = schema.findField(columns.get(i));
+      byte[] buffer = (byte[]) embeddings.get(i);
+      TextEmbeddingBuffer textEmbeddingBuffer = TextEmbeddingBuffer.deserialize(buffer);
+      blobs.add(toBlob(field, buffer, textEmbeddingBuffer.getTextEmbeddings().size(), snapshot));
+    }
+    return blobs;
+  }
+
+  private static Blob toBlob(
+      Types.NestedField field, byte[] serializedEmbeddings, long numEmbeddings, Snapshot snapshot) {
+    return new Blob(
+        StandardBlobTypes.EMBEDDINGS_V1,
+        ImmutableList.of(field.fieldId()),
+        snapshot.snapshotId(),
+        snapshot.sequenceNumber(),
+        ByteBuffer.wrap(serializedEmbeddings),
+        PuffinCompressionCodec.ZSTD,
+        ImmutableMap.of(NUM_EMBEDDINGS, String.valueOf(numEmbeddings)));
+  }
+
+  private static Row computeEmbeddings(
+      SparkSession spark,
+      Table table,
+      Snapshot snapshot,
+      List<String> colNames,
+      String modelName,
+      Map<String, String> modelInputs) {
+    Dataset<Row> inputDF = SparkTableUtil.loadTable(spark, table, snapshot.snapshotId());
+    return inputDF.select(toAggColumns(colNames, modelName, modelInputs)).first();
+  }
+
+  private static Column[] toAggColumns(
+      List<String> colNames, String modelName, Map<String, String> modelInputs) {
+    return colNames.stream()
+        .map(column -> TextEmbeddingPuffinWriter.toAggColumn(column, modelName, modelInputs))
+        .toArray(Column[]::new);
+  }
+
+  private static Column toAggColumn(
+      String colName, String modelName, Map<String, String> modelInputs) {
+    EmbeddingAgg agg =
+        new EmbeddingAgg(
+            colName,
+            modelName,
+            JavaConverters.mapAsScalaMapConverter(modelInputs)
+                .asScala()
+                .toMap(Predef.<Tuple2<String, String>>conforms()));
+    return new Column(agg.toAggregateExpression());
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingUtil.java
@@ -43,7 +43,7 @@ import scala.collection.JavaConverters;
 
 public class TextEmbeddingUtil {
 
-  private static final String NUM_EMBEDDINGS = "num_embeddings";
+  public static final String EMBEDDINGS_V1_BLOB_PROPERTY = "embeddings";
 
   private TextEmbeddingUtil() {}
 
@@ -75,7 +75,7 @@ public class TextEmbeddingUtil {
         snapshot.sequenceNumber(),
         ByteBuffer.wrap(serializedEmbeddings),
         PuffinCompressionCodec.ZSTD,
-        ImmutableMap.of(NUM_EMBEDDINGS, String.valueOf(numEmbeddings)));
+        ImmutableMap.of(EMBEDDINGS_V1_BLOB_PROPERTY, String.valueOf(numEmbeddings)));
   }
 
   private static Row computeEmbeddings(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/TextEmbeddingUtil.java
@@ -41,11 +41,11 @@ import scala.Predef;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
 
-public class TextEmbeddingPuffinWriter {
+public class TextEmbeddingUtil {
 
   private static final String NUM_EMBEDDINGS = "num_embeddings";
 
-  private TextEmbeddingPuffinWriter() {}
+  private TextEmbeddingUtil() {}
 
   static List<Blob> generateBlobs(
       SparkSession spark,
@@ -92,7 +92,7 @@ public class TextEmbeddingPuffinWriter {
   private static Column[] toAggColumns(
       List<String> colNames, String modelName, Map<String, String> modelInputs) {
     return colNames.stream()
-        .map(column -> TextEmbeddingPuffinWriter.toAggColumn(column, modelName, modelInputs))
+        .map(column -> TextEmbeddingUtil.toAggColumn(column, modelName, modelInputs))
         .toArray(Column[]::new);
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ComputeTableEmbeddingsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ComputeTableEmbeddingsProcedure.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.actions.ComputeTableEmbeddings;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class ComputeTableEmbeddingsProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter TABLE_PARAM =
+      ProcedureParameter.required("table", DataTypes.StringType);
+  private static final ProcedureParameter SNAPSHOT_ID_PARAM =
+      ProcedureParameter.optional("snapshot_id", DataTypes.LongType);
+  private static final ProcedureParameter COLUMNS_PARAM =
+      ProcedureParameter.optional("columns", STRING_ARRAY);
+  private static final ProcedureParameter MODEL_NAME_PARAM =
+      ProcedureParameter.required("model_name", DataTypes.StringType);
+  private static final ProcedureParameter MODEL_INPUTS_PARAM =
+      ProcedureParameter.required("model_inputs", STRING_MAP);
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {
+        TABLE_PARAM, SNAPSHOT_ID_PARAM, COLUMNS_PARAM, MODEL_NAME_PARAM, MODEL_INPUTS_PARAM
+      };
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField("statistics_file", DataTypes.StringType, true, Metadata.empty())
+          });
+
+  public static ProcedureBuilder builder() {
+    return new Builder<ComputeTableEmbeddingsProcedure>() {
+      @Override
+      protected ComputeTableEmbeddingsProcedure doBuild() {
+        return new ComputeTableEmbeddingsProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private ComputeTableEmbeddingsProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+    Identifier tableIdent = input.ident(TABLE_PARAM);
+    Long snapshotId = input.asLong(SNAPSHOT_ID_PARAM, null);
+    String[] columns = input.asStringArray(COLUMNS_PARAM, null);
+    return modifyIcebergTable(
+        tableIdent,
+        table -> {
+          ComputeTableEmbeddings action = actions().computeTableEmbeddings(table);
+
+          if (snapshotId != null) {
+            action.snapshot(snapshotId);
+          }
+
+          if (columns != null) {
+            action.columns(columns);
+          }
+
+          ComputeTableEmbeddings.Result result = action.execute();
+          return toOutputRows(result);
+        });
+  }
+
+  private InternalRow[] toOutputRows(ComputeTableEmbeddings.Result result) {
+    StatisticsFile statisticsFile = result.statisticsFile();
+    if (statisticsFile != null) {
+      InternalRow row = newInternalRow(UTF8String.fromString(statisticsFile.path()));
+      return new InternalRow[] {row};
+    } else {
+      return new InternalRow[0];
+    }
+  }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -62,6 +62,7 @@ public class SparkProcedures {
     mapBuilder.put("rewrite_position_delete_files", RewritePositionDeleteFilesProcedure::builder);
     mapBuilder.put("fast_forward", FastForwardBranchProcedure::builder);
     mapBuilder.put("compute_table_stats", ComputeTableStatsProcedure::builder);
+    mapBuilder.put("compute_table_embeddings", ComputeTableEmbeddingsProcedure::builder);
     return mapBuilder.build();
   }
 

--- a/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
+++ b/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
@@ -1,0 +1,100 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.spark.sql.index
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import dev.langchain4j.data.document.Metadata
+import dev.langchain4j.data.embedding.Embedding
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ImperativeAggregate, TypedImperativeAggregate}
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.types.{BinaryType, DataType}
+
+import java.nio.charset.StandardCharsets
+
+case class EmbeddingAgg(
+                         child: Expression,
+                         mutableAggBufferOffset: Int = 0,
+                         inputAggBufferOffset: Int = 0) extends TypedImperativeAggregate[List[(TextSegment, Embedding)]]
+  with UnaryLike[Expression] {
+
+  override def nullable: Boolean = false
+
+  override def dataType: DataType = BinaryType
+
+  override def createAggregationBuffer(): List[(TextSegment, Embedding)] = {
+    List.empty[(TextSegment, Embedding)]
+  }
+
+  override def update(buffer: List[(TextSegment, Embedding)], input: InternalRow): List[(TextSegment, Embedding)] = {
+    val value = child.eval(input)
+    if (value != null && value.isInstanceOf[String]) {
+      val embeddingModel: EmbeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel()
+      val metadata: Metadata = new Metadata()
+      val textSegment: TextSegment = TextSegment.from(value.toString, metadata)
+      val embedding: Embedding = embeddingModel.embed(textSegment).content()
+      (textSegment, embedding) :: buffer
+    } else {
+      null
+    }
+  }
+
+  override def merge(buffer: List[(TextSegment, Embedding)], input: List[(TextSegment, Embedding)]):
+  List[(TextSegment, Embedding)] = buffer ::: input
+
+  override def eval(buffer: List[(TextSegment, Embedding)]): Any = {
+    toBytes(buffer)
+  }
+
+  private def toBytes(buffer: List[(TextSegment, Embedding)]) = {
+    val gson = new Gson()
+    gson.toJson(buffer).getBytes(StandardCharsets.UTF_8)
+  }
+
+  override def serialize(buffer: List[(TextSegment, Embedding)]): Array[Byte] = {
+    toBytes(buffer)
+  }
+
+  override def deserialize(storageFormat: Array[Byte]): List[(TextSegment, Embedding)] = {
+    val jsonString = new String(storageFormat, StandardCharsets.UTF_8)
+    val listType = new TypeToken[List[(TextSegment, Embedding)]]() {}.getType
+    val gson = new Gson()
+    gson.fromJson(jsonString, listType)
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = {
+    copy(child = newChild)
+  }
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate = {
+    copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+  }
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate = {
+    copy(inputAggBufferOffset = newInputAggBufferOffset)
+  }
+}

--- a/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
+++ b/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
@@ -21,73 +21,89 @@
 
 package org.apache.spark.sql.index
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
 import dev.langchain4j.data.document.Metadata
 import dev.langchain4j.data.embedding.Embedding
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.model.embedding.EmbeddingModel
-import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel
+import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel
+import dev.langchain4j.model.ollama.OllamaEmbeddingModel
+import dev.langchain4j.model.output.Response
+import org.apache.iceberg.spark.actions.{TextEmbedding, TextEmbeddingBuffer}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.aggregate.{ImperativeAggregate, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{BinaryType, DataType}
+import org.apache.spark.unsafe.types.UTF8String
 
-import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.Collections
 
 case class EmbeddingAgg(
                          child: Expression,
                          mutableAggBufferOffset: Int = 0,
-                         inputAggBufferOffset: Int = 0) extends TypedImperativeAggregate[List[(TextSegment, Embedding)]]
+                         inputAggBufferOffset: Int = 0) extends TypedImperativeAggregate[TextEmbeddingBuffer]
   with UnaryLike[Expression] {
 
   override def nullable: Boolean = false
 
   override def dataType: DataType = BinaryType
 
-  override def createAggregationBuffer(): List[(TextSegment, Embedding)] = {
-    List.empty[(TextSegment, Embedding)]
+  def this(colName: String) = {
+    this(col(colName).expr, 0, 0)
   }
 
-  override def update(buffer: List[(TextSegment, Embedding)], input: InternalRow): List[(TextSegment, Embedding)] = {
+  override def createAggregationBuffer(): TextEmbeddingBuffer = {
+    val emptyList: java.util.List[TextEmbedding] = Collections.emptyList()
+    new TextEmbeddingBuffer(emptyList)
+  }
+
+  override def update(buffer: TextEmbeddingBuffer, input: InternalRow): TextEmbeddingBuffer = {
     val value = child.eval(input)
-    if (value != null && value.isInstanceOf[String]) {
-      val embeddingModel: EmbeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel()
+    if (value != null && value.isInstanceOf[UTF8String]) {
+
+      System.setProperty("ai.djl.offline", "true")
+      System.setProperty("DJL_OFFLINE", "true")
+
+      val embeddingModel = new AllMiniLmL6V2EmbeddingModel()
+      val response : Response[Embedding] = embeddingModel.embed(value.toString)
+      print(response.content())
+
+      val ollamaModel : EmbeddingModel = new OllamaEmbeddingModel(
+        "http://localhost:11434/",
+        "llama3.1",
+        Duration.ofSeconds(60),
+        3,
+        true,
+        true,
+        Collections.emptyMap()
+      )
+
       val metadata: Metadata = new Metadata()
       val textSegment: TextSegment = TextSegment.from(value.toString, metadata)
-      val embedding: Embedding = embeddingModel.embed(textSegment).content()
-      (textSegment, embedding) :: buffer
+      val embedding: Embedding = ollamaModel.embed(textSegment).content()
+      val singletonList: java.util.List[TextEmbedding] = Collections.singletonList(new TextEmbedding(textSegment, embedding))
+      buffer.merge(new TextEmbeddingBuffer(singletonList))
     } else {
-      null
+      val emptyList: java.util.List[TextEmbedding] = Collections.emptyList()
+      new TextEmbeddingBuffer(emptyList)
     }
   }
 
-  override def merge(buffer: List[(TextSegment, Embedding)], input: List[(TextSegment, Embedding)]):
-  List[(TextSegment, Embedding)] = buffer ::: input
+  override def merge(buffer: TextEmbeddingBuffer, input: TextEmbeddingBuffer):
+  TextEmbeddingBuffer = buffer.merge(input)
 
-  override def eval(buffer: List[(TextSegment, Embedding)]): Any = {
-    toBytes(buffer)
+  override def eval(buffer: TextEmbeddingBuffer): Any = {
+    buffer.serialize()
   }
 
-  private def toBytes(buffer: List[(TextSegment, Embedding)]) = {
-    val gson = new Gson()
-    gson.toJson(buffer).getBytes(StandardCharsets.UTF_8)
+  override def serialize(buffer: TextEmbeddingBuffer): Array[Byte] = {
+    buffer.serialize()
   }
 
-  override def serialize(buffer: List[(TextSegment, Embedding)]): Array[Byte] = {
-    toBytes(buffer)
-  }
-
-  override def deserialize(storageFormat: Array[Byte]): List[(TextSegment, Embedding)] = {
-    val jsonString = new String(storageFormat, StandardCharsets.UTF_8)
-    val listType = new TypeToken[List[(TextSegment, Embedding)]]() {}.getType
-    val gson = new Gson()
-    gson.fromJson(jsonString, listType)
-  }
-
-  override protected def withNewChildInternal(newChild: Expression): Expression = {
-    copy(child = newChild)
+  override def deserialize(storageFormat: Array[Byte]): TextEmbeddingBuffer = {
+    TextEmbeddingBuffer.deserialize(storageFormat)
   }
 
   override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int): ImperativeAggregate = {
@@ -97,4 +113,12 @@ case class EmbeddingAgg(
   override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int): ImperativeAggregate = {
     copy(inputAggBufferOffset = newInputAggBufferOffset)
   }
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = {
+    copy(child = newChild)
+  }
+
+
 }
+
+

--- a/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
+++ b/spark/v3.5/spark/src/main/scala/org/apache/spark/sql/index/EmbeddingAgg.scala
@@ -72,14 +72,14 @@ case class EmbeddingAgg(
     val value = child.eval(input)
     if (value != null && value.isInstanceOf[UTF8String]) {
 
-      val metadata: Metadata = new Metadata()
-      metadata.put("column_name", columnName)
-      metadata.put("model_name", modelName)
-      val textSegment: TextSegment = TextSegment.from(value.toString, metadata)
       val embeddingModel: EmbeddingModel = EmbeddingModelBuilder.builder()
         .modelName(modelName)
         .modelInputs(modelInputs.asJava)
         .build()
+      val metadata: Metadata = new Metadata()
+      metadata.put("column_name", columnName)
+      metadata.put("model_name", modelName)
+      val textSegment: TextSegment = TextSegment.from(value.toString, metadata)
       val embedding: Embedding = embeddingModel.embed(textSegment).content()
       val singletonList: java.util.List[TextEmbedding] =
         Collections.singletonList(new TextEmbedding(textSegment, embedding))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableEmbeddingsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableEmbeddingsAction.java
@@ -33,7 +33,6 @@ import dev.langchain4j.store.embedding.EmbeddingSearchResult;
 import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -541,7 +540,7 @@ public class TestComputeTableEmbeddingsAction extends CatalogTestBase {
   private List<TextEmbeddingBuffer> getTextEmbeddingBuffers(
       Table table, StatisticsFile statisticsFile) {
     InputFile inputFile = table.io().newInputFile(statisticsFile.path());
-    List<TextEmbeddingBuffer> textEmbeddingBuffers = new ArrayList<>();
+    List<TextEmbeddingBuffer> textEmbeddingBuffers = Lists.newArrayList();
 
     try (PuffinReader puffinReader = Puffin.read(inputFile).build()) {
       Iterable<org.apache.iceberg.util.Pair<org.apache.iceberg.puffin.BlobMetadata, ByteBuffer>>

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableEmbeddingsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestComputeTableEmbeddingsAction.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.spark.actions.TextEmbeddingUtil.EMBEDDINGS_V1_BLOB_PROPERTY;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.BlobMetadata;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.ComputeTableEmbeddings;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestComputeTableEmbeddingsAction extends CatalogTestBase {
+
+  // In-process model
+  private static final String MODEL_NAME = EmbeddingModelBuilder.ALL_MINI_LM_L6V2;
+  private static final Map<String, String> MODEL_INPUTS = Collections.emptyMap();
+
+  private static final Types.StructType LEAF_STRUCT_TYPE =
+      Types.StructType.of(
+          optional(1, "leafLongCol", Types.LongType.get()),
+          optional(2, "leafStringCol", Types.StringType.get()));
+
+  private static final Types.StructType NESTED_STRUCT_TYPE =
+      Types.StructType.of(required(3, "leafStructCol", LEAF_STRUCT_TYPE));
+
+  private static final Schema NESTED_SCHEMA =
+      new Schema(required(4, "nestedStructCol", NESTED_STRUCT_TYPE));
+
+  private static final Schema SCHEMA_WITH_NESTED_COLUMN =
+      new Schema(
+          required(4, "nestedStructCol", NESTED_STRUCT_TYPE),
+          required(5, "stringCol", Types.StringType.get()));
+
+  @TestTemplate
+  public void testLoadingTableDirectly() {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    sql("INSERT into %s values(1, 'abcd')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkActions actions = SparkActions.get();
+    ComputeTableEmbeddings.Result results =
+        actions
+            .computeTableEmbeddings(table)
+            .modelName(MODEL_NAME)
+            .modelInputs(MODEL_INPUTS)
+            .columns("data")
+            .execute();
+    StatisticsFile statisticsFile = results.statisticsFile();
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsAction() throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    // To create multiple splits on the mapper
+    table
+        .updateProperties()
+        .set("read.split.target-size", "100")
+        .set("write.parquet.row-group-size-bytes", "100")
+        .commit();
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "c"),
+            new SimpleRecord(4, "d"));
+    spark.createDataset(records, Encoders.bean(SimpleRecord.class)).writeTo(tableName).append();
+    SparkActions actions = SparkActions.get();
+    table.refresh();
+    ComputeTableEmbeddings.Result results =
+        actions
+            .computeTableEmbeddings(table)
+            .modelName(MODEL_NAME)
+            .modelInputs(MODEL_INPUTS)
+            .columns("data")
+            .execute();
+    assertThat(results).isNotNull();
+
+    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
+    assertThat(statisticsFiles).hasSize(1);
+
+    StatisticsFile statisticsFile = statisticsFiles.get(0);
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+
+    BlobMetadata blobMetadata = statisticsFile.blobMetadata().get(0);
+    assertThat(blobMetadata.properties()).containsEntry(EMBEDDINGS_V1_BLOB_PROPERTY, "5");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsForInvalidColumns()
+      throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    // Append data to create snapshot
+    sql("INSERT into %s values(1, 'abcd')", tableName);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    SparkActions actions = SparkActions.get();
+    assertThatThrownBy(() -> actions.computeTableEmbeddings(table).columns("id1").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Can't find column id1 in table");
+    assertThatThrownBy(() -> actions.computeTableEmbeddings(table).columns("id").execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Can't compute embeddings on non-string type columns: id (int)");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsWithNoSnapshots()
+      throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    SparkActions actions = SparkActions.get();
+    ComputeTableEmbeddings.Result result =
+        actions.computeTableEmbeddings(table).columns("id").execute();
+    assertThat(result.statisticsFile()).isNull();
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsWithNullValues()
+      throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, null),
+            new SimpleRecord(1, "a"),
+            new SimpleRecord(2, "b"),
+            new SimpleRecord(3, "c"),
+            new SimpleRecord(4, "d"));
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    SparkActions actions = SparkActions.get();
+    ComputeTableEmbeddings.Result results =
+        actions
+            .computeTableEmbeddings(table)
+            .columns("data")
+            .modelName(MODEL_NAME)
+            .modelInputs(MODEL_INPUTS)
+            .execute();
+    assertThat(results).isNotNull();
+
+    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
+    assertThat(statisticsFiles).hasSize(1);
+
+    StatisticsFile statisticsFile = statisticsFiles.get(0);
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+
+    assertThat(statisticsFile.blobMetadata().get(0).properties())
+        .containsEntry(EMBEDDINGS_V1_BLOB_PROPERTY, "4");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsWithSnapshotHavingDifferentSchemas()
+      throws NoSuchTableException, ParseException {
+    SparkActions actions = SparkActions.get();
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    // Append data to create snapshot
+    sql("INSERT into %s values(1, 'abcd')", tableName);
+    long snapshotId1 = Spark3Util.loadIcebergTable(spark, tableName).currentSnapshot().snapshotId();
+    // Snapshot id not specified
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                actions
+                    .computeTableEmbeddings(table)
+                    .modelName(MODEL_NAME)
+                    .modelInputs(MODEL_INPUTS)
+                    .columns("data")
+                    .execute());
+
+    sql("ALTER TABLE %s DROP COLUMN %s", tableName, "data");
+    // Append data to create snapshot
+    sql("INSERT into %s values(1)", tableName);
+    table.refresh();
+    long snapshotId2 = Spark3Util.loadIcebergTable(spark, tableName).currentSnapshot().snapshotId();
+
+    // Snapshot id specified
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                actions
+                    .computeTableEmbeddings(table)
+                    .snapshot(snapshotId1)
+                    .modelName(MODEL_NAME)
+                    .modelInputs(MODEL_INPUTS)
+                    .columns("data")
+                    .execute());
+
+    assertThatThrownBy(
+            () ->
+                actions
+                    .computeTableEmbeddings(table)
+                    .snapshot(snapshotId2)
+                    .modelName(MODEL_NAME)
+                    .modelInputs(MODEL_INPUTS)
+                    .columns("data")
+                    .execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Can't find column data in table");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsWhenSnapshotIdNotSpecified()
+      throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, data string) USING iceberg", tableName);
+    // Append data to create snapshot
+    sql("INSERT into %s values(1, 'abcd')", tableName);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    SparkActions actions = SparkActions.get();
+    ComputeTableEmbeddings.Result results =
+        actions
+            .computeTableEmbeddings(table)
+            .modelName(MODEL_NAME)
+            .modelInputs(MODEL_INPUTS)
+            .columns("data")
+            .execute();
+
+    assertThat(results).isNotNull();
+
+    List<StatisticsFile> statisticsFiles = table.statisticsFiles();
+    assertThat(statisticsFiles).hasSize(1);
+
+    StatisticsFile statisticsFile = statisticsFiles.get(0);
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+
+    assertThat(statisticsFile.blobMetadata().get(0).properties())
+        .containsEntry(EMBEDDINGS_V1_BLOB_PROPERTY, "1");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsWithNestedSchema()
+      throws NoSuchTableException, ParseException, IOException {
+    List<Record> records = Lists.newArrayList(createNestedRecord());
+    Table table =
+        validationCatalog.createTable(
+            tableIdent,
+            SCHEMA_WITH_NESTED_COLUMN,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+    table.newAppend().appendFile(dataFile).commit();
+
+    Table tbl = Spark3Util.loadIcebergTable(spark, tableName);
+    SparkActions actions = SparkActions.get();
+    actions
+        .computeTableEmbeddings(tbl)
+        .modelName(MODEL_NAME)
+        .modelInputs(MODEL_INPUTS)
+        .columns("nestedStructCol.leafStructCol.leafStringCol")
+        .execute();
+
+    tbl.refresh();
+    List<StatisticsFile> statisticsFiles = tbl.statisticsFiles();
+    assertThat(statisticsFiles).hasSize(1);
+    StatisticsFile statisticsFile = statisticsFiles.get(0);
+    assertThat(statisticsFile.fileSizeInBytes()).isGreaterThan(0);
+    assertThat(statisticsFile.blobMetadata()).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingWithNoComputableColumns() throws IOException {
+    List<Record> records = Lists.newArrayList(createNestedRecord());
+    Table table =
+        validationCatalog.createTable(
+            tableIdent, NESTED_SCHEMA, PartitionSpec.unpartitioned(), ImmutableMap.of());
+    DataFile dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.toFile()), records);
+    table.newAppend().appendFile(dataFile).commit();
+
+    table.refresh();
+    SparkActions actions = SparkActions.get();
+    assertThatThrownBy(() -> actions.computeTableEmbeddings(table).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No columns found to compute embeddings");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnByteColumn() throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("byte_col", "TINYINT");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnShortColumn()
+      throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("short_col", "SMALLINT");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnIntColumn() throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("int_col", "INT");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnLongColumn() throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("long_col", "BIGINT");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnTimestampColumn()
+      throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("timestamp_col", "TIMESTAMP");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnTimestampNtzColumn()
+      throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("timestamp_col", "TIMESTAMP_NTZ");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnDateColumn() throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("date_col", "DATE");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnDecimalColumn()
+      throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("decimal_col", "DECIMAL(20, 2)");
+  }
+
+  @TestTemplate
+  public void testComputeTableEmbeddingsOnBinaryColumn()
+      throws NoSuchTableException, ParseException {
+    testComputeTableEmbeddingsAllInvalidColumns("binary_col", "BINARY");
+  }
+
+  public void testComputeTableEmbeddingsAllInvalidColumns(String columnName, String type)
+      throws NoSuchTableException, ParseException {
+    sql("CREATE TABLE %s (id int, %s %s) USING iceberg", tableName, columnName, type);
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    Dataset<Row> dataDF = randomDataDF(table.schema());
+    append(tableName, dataDF);
+
+    SparkActions actions = SparkActions.get();
+    table.refresh();
+    assertThatThrownBy(() -> actions.computeTableEmbeddings(table).columns(columnName).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Can't compute embeddings on non-string type columns: %s", columnName);
+  }
+
+  private GenericRecord createNestedRecord() {
+    GenericRecord record = GenericRecord.create(SCHEMA_WITH_NESTED_COLUMN);
+    GenericRecord nested = GenericRecord.create(NESTED_STRUCT_TYPE);
+    GenericRecord leaf = GenericRecord.create(LEAF_STRUCT_TYPE);
+    leaf.set(0, 0L);
+    leaf.set(1, "iceberg");
+    nested.set(0, leaf);
+    record.set(0, nested);
+    record.set(1, "data");
+    return record;
+  }
+
+  private Dataset<Row> randomDataDF(Schema schema) {
+    Iterable<InternalRow> rows = RandomData.generateSpark(schema, 10, 0);
+    JavaRDD<InternalRow> rowRDD = sparkContext.parallelize(Lists.newArrayList(rows));
+    StructType rowSparkType = SparkSchemaUtil.convert(schema);
+    return spark.internalCreateDataFrame(JavaRDD.toRDD(rowRDD), rowSparkType, false);
+  }
+
+  private void append(String table, Dataset<Row> df) throws NoSuchTableException {
+    // fanout writes are enabled as write-time clustering is not supported without Spark extensions
+    df.coalesce(1).writeTo(table).option(SparkWriteOptions.FANOUT_ENABLED, "true").append();
+  }
+
+  @AfterEach
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+}


### PR DESCRIPTION
The PR supports the following:

1. Spark action to compute embedding for text columns in an Iceberg table.
2. Write a serialized representation of the embedding to Puffin file and make it available in table metadata.
3. Add unit-test to check writing and reading embedding, and perform similarity search with cosine similarity and retriever model / embedding store.
4. To be continued...